### PR TITLE
Added downloading of speeches

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ Upload a speech
 otter.upload_speech(FILE_NAME)
 ```
 
+Download a speech
+
+**optional parameters**: filename (defualt id), format (default: all available (txt,pdf,mp3,docx,srt) as zip file)
+
+```python
+otter.download_speech(FILE_NAME)
+```
+
 Move a speech to trash
 
 ```python

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Download a speech
 **optional parameters**: filename (defualt id), format (default: all available (txt,pdf,mp3,docx,srt) as zip file)
 
 ```python
-otter.download_speech(FILE_NAME)
+otter.download_speech(SPEECH_ID, FILE_NAME)
 ```
 
 Move a speech to trash

--- a/otterai/otterai.py
+++ b/otterai/otterai.py
@@ -164,7 +164,7 @@ class OtterAI:
 
         return self._handle_response(response)
 
-    def download_speech(self, speech_id, fileformat="txt,pdf,mp3,docx,srt", name=None):
+    def download_speech(self, speech_id, name=None, fileformat="txt,pdf,mp3,docx,srt"):
         # API URL
         download_speech_url = OtterAI.API_BASE_URL + 'bulk_export'
         if self._is_userid_invalid():
@@ -181,7 +181,7 @@ class OtterAI:
             with open(filename, "wb") as f:
                 f.write(response.content)
         else:
-            raise OtterAIException(f"Got response {r.ok} when attempting to download {speech_id}")
+            raise OtterAIException(f"Got response status {response.status_code} when attempting to download {speech_id}")
         return self._handle_response(response, data={"filename": filename})
 
     def move_to_trash_bin(self, speech_id):


### PR DESCRIPTION
Added basic functionality for downloading a speech. 

Usage example:

```
# ID = some otter speech id
otter.download_speech(ID) # downloads ID.zip with all formats available for ID
otter.download_speech(ID, fileformat="pdf") # downloads ID.pdf
otter.download_speech(ID, fileformat="pdf", name="speech") # downloads ID pdf as speech.pdf
```

Had to make small edit to _handle_response, I think the code explains itself well but I'm also happy to answer questions!

:slightly_smiling_face: 