### PR TITLE
Add stream_speech, list_folder_speeches, and fix bug with move_to_trash_bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ Get all speeches
 otter.get_speeches()
 ```
 
+Get all speeches in a folder
+
+**optional parameters**: page_size, last_load_speech_id
+
+```python
+otter.list_folder_speeches(folder_id=FOLDER_ID)
+```
+
 Get speech by id
 
 ```python
@@ -77,6 +85,14 @@ Download a speech
 
 ```python
 otter.download_speech(SPEECH_ID, FILE_NAME)
+```
+
+Stream a speech
+
+**optional parameters**: format (default: mp4)
+
+```python
+otter.stream_speech(SPEECH_ID)
 ```
 
 Move a speech to trash


### PR DESCRIPTION
– Added `stream_speech`
– Added `list_folder_speeches`
– Fixed bug with `move_to_trash_bin`

Stream speech adds the ability to return the content of the speech directly rather than saving to a file. I considered refactoring `download_speech` but I felt this was cleaner and ensures backwards compatibility.

List folder speeches enables you to query speeches from only a specific folder. I found that the `folder` parameter on `get_speeches` doesn't seem to work, and this is the query that Otter uses when you are looking into a folder via the UI. Since we're trying to mimic the API I didn't want to refactor the `get_speeches()` function. It also allows for pagination via the `last_load_speech_id` argument.

Move to trash bin was failing with a referrer error, so I made sure to add the referrer already present in a number of other functions.