### PR TITLE
Fix get_speech to include both otid and speech_id

### DIFF
--- a/otterai/otterai.py
+++ b/otterai/otterai.py
@@ -81,13 +81,13 @@ class OtterAI:
 
         return self._handle_response(response)
 
-    def get_speech(self, speech_id):
+    def get_speech(self, ot_id, speech_id):
         # API URL
         speech_url = OtterAI.API_BASE_URL + 'speech'
         if self._is_userid_invalid():
             raise OtterAIException('userid is invalid')
         # Query Params
-        payload = {'userid': self._userid, 'otid': speech_id}
+        payload = {'userid': self._userid, 'otid': ot_id, 'speech_id': speech_id}
         # GET
         response = self._session.get(speech_url, params=payload)
 

--- a/otterai/otterai.py
+++ b/otterai/otterai.py
@@ -81,13 +81,13 @@ class OtterAI:
 
         return self._handle_response(response)
 
-    def get_speech(self, ot_id, speech_id):
+    def get_speech(self, otid, speech_id):
         # API URL
         speech_url = OtterAI.API_BASE_URL + 'speech'
         if self._is_userid_invalid():
             raise OtterAIException('userid is invalid')
         # Query Params
-        payload = {'userid': self._userid, 'otid': ot_id, 'speech_id': speech_id}
+        payload = {'userid': self._userid, 'otid': otid, 'speech_id': speech_id}
         # GET
         response = self._session.get(speech_url, params=payload)
 


### PR DESCRIPTION
The get speech function requires both otid and speech_id. Currently it sets otid to speech_id which is incorrect.